### PR TITLE
Added Violin\Support\MessageBag that handles the message output. Added v...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require-dev": {
-        "squizlabs/php_codesniffer": "2.1.*"
+        "squizlabs/php_codesniffer": "2.1.*",
+        "phpunit/phpunit": "4.5.0"
     },
 	"autoload": {
 		"psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Violin Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Rules/Between.php
+++ b/src/Rules/Between.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Violin\Rules;
+
+class Between
+{
+    /**
+     * Run the validation
+     *
+     * @param  string $name
+     * @param  mixed $value
+     * @return bool
+     */
+    public function run($name, $value, $param1, $param2)
+    {
+        return ($value >= $param1 && $value <= $param2) ? true : false;
+    }
+
+}

--- a/src/Support/MessageBag.php
+++ b/src/Support/MessageBag.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Violin\Support;
+
+class MessageBag
+{
+    /**
+     * The registered messages.
+     *
+     * @var array
+     */
+    protected $messages = [];
+
+    /**
+     * Creates a new instange of the MessageBag instance.
+     *
+     * @param array $messages
+     * @return void
+     */
+    public function __construct(array $messages)
+    {
+        foreach ($messages as $key => $value) {
+            $this->messages[$key] = (array) $value;
+        }
+    }
+
+    /**
+     * Checks if the bag has messages for a given key.
+     *
+     * @param  string  $key
+     * @return boolean
+     */
+    public function has($key)
+    {
+        return ! is_null($this->first($key));
+    }
+
+    /**
+     * Get the first message with a given key.
+     * If the given key doesn't exist, it returns the first
+     * message of the bag.
+     * Returns null if the bag is empty.
+     *
+     * @param  string $key
+     * @return string|null
+     */
+    public function first($key = null)
+    {
+        $messages = is_null($key) ? $this->all() : $this->get($key);
+        return (count($messages) > 0) ? $messages[0] : null;
+    }
+
+    /**
+     * Get all of the messages from a given key.
+     * Returns null if the given key is empty, or
+     * if it doesn't exist.
+     *
+     * @param  string $key
+     * @return array|null
+     */
+    public function get($key)
+    {
+        if (array_key_exists($key, $this->messages)) {
+            return !empty($this->messages[$key]) ? $this->messages[$key] : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get all of the messages in the bag.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        $messages = [];
+
+        foreach ($this->messages as $key => $value) {
+            $messages[] = $value;
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Return all of the keys in the bag.
+     *
+     * @return array
+     */
+    public function keys()
+    {
+        return array_keys($this->messages);
+    }
+}

--- a/tests/RulesTest.php
+++ b/tests/RulesTest.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Violin\Violin;
+
+class RulesTest extends PHPUnit_Framework_TestCase
+{
+    public $v;
+
+    public function setUp()
+    {
+        $this->v = new Violin;
+    }
+
+    public function testBetween()
+    {
+        $this->v->validate(['age' => 10], ['age' => 'required|int|between(10, 20)']);
+        $this->assertTrue($this->v->valid());
+
+        $this->v->validate(['age' => 1], ['age' => 'required|int|between(10, 20)']);
+        $this->assertFalse($this->v->valid());
+
+        $this->v->validate(['age' => 1], ['age' => 'required|int|between(10, 20)']);
+        $this->assertEquals('age must be between [10, 20].', $this->v->messages()->first('age'));
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+require_once 'vendor/autoload.php';
+
+use Violin\Violin;
+
+class ValidatorTest extends PHPUnit_Framework_TestCase
+{
+
+    public $v;
+
+    public function setUp()
+    {
+        $this->v = new Violin;
+    }
+
+    public function testBasicValidationWithValidData()
+    {
+        $this->v->validate(['name' => 'billy'], ['name' => 'required']);
+        $this->assertTrue($this->v->valid());
+    }
+
+    public function testBasicValidationWithInvalidData()
+    {
+        $this->v->validate(['name' => ''], ['name' => 'required']);
+        $this->assertFalse($this->v->valid());
+    }
+
+    public function testCustomFieldMessage()
+    {
+        $message = 'You need to enter a username to sign up.';
+        $this->v->addFieldMessage('username', 'required', $message);
+        $this->v->validate(['username' => ''], ['username' => 'required']);
+        $this->assertFalse($this->v->valid());
+        $this->assertEquals($message, $this->v->messages()->first('username'));
+    }
+
+    public function testCustomRule()
+    {
+        $this->v->addRuleMessage('isBanana', '{field} expects banana, found "{value}" instead.');
+
+        $this->v->addRule('isBanana', function($field, $value) {
+            return $value === 'banana';
+        });
+
+        $this->v->validate(['name' => 'billy'], ['name' => 'isBanana']);
+
+        $this->assertFalse($this->v->valid());
+    }
+
+    public function testCustomRuleMessage()
+    {
+        $this->v->addRuleMessage('required', 'You better fill in the {field} field, or else.');
+
+        $this->v->validate(['name' => ''], ['name' => 'required']);
+
+        $this->assertEquals('You better fill in the name field, or else.', $this->v->messages()->first('name'));
+    }
+
+    public function testParameters()
+    {
+        $this->v->addFieldMessages([
+            'age' => [
+                'max' => '{field} is {input} but cannot be more than {value}.'
+            ]
+        ]);
+
+        $this->v->validate(['age' => 101], ['age' => 'max(100)']);
+        $this->v->assertFalse($this->v->valid());
+    }
+
+    public function testMessageBag()
+    {
+        $this->v->addFieldMessage('age', 'min', 'Your {field} should be at least higher than {value}.');
+        $this->v->validate(['name' => '', 'age' => 9], ['name' => 'required', 'age' => 'required|int|min(10)']);
+        $this->assertTrue($this->v->messages()->has('age'));
+        $this->assertEquals(2, count($this->v->messages()->all()));
+        $this->assertEquals('Your age should be at least higher than 10.', $this->v->messages()->first('age'));
+        $this->assertEquals(['name', 'age'], $this->v->messages()->keys());
+    }
+
+}


### PR DESCRIPTION
...ery basic unit testing. Added support to get multiple values from rule messages for rules that have multiple arguments, and included the Between rule.

@alexgarrett So, I wanted to discuss some changes I've made today into the project.
I've implemented some basic unit testing into the project as asked for in Issue #6.

I also added another rule: Between. This rule checks if a number is within an closed interval. It's pretty straight forward.

In regards to the error structure, I managed to develop the MessageBag. I created the messages() method in Violin\Validator\Validator which picks the errors from the errors array and generates the messages and then returns an instance of Violin\Support\MessageBag
In this class we can define the methods you were referring, so that we can easily manipulate error message output.

 I also changed the way that we can format rule messages. I've created an array in Violin\Validator\Validator that has the default value of:
 ```php 
public $format = ['{field}', '{input}', '{value}']; 
```
And I also added the replace() method. What this method does is it looks for the format in the string and replaces it with the arguments of the rule.
Since Violin supports multiple parameters for rules definitions, I had to hack the replace() method a bit, therefore it kinda looks a little bit messy. What I am talking about is this:
```php
if (count($arguments) > 3) {
            // If the arguments array is bigger than the format
            // array, then we need to consider that the rule has
            // multiple paramaters.
            $format = $this->format;

            for ($i = 2; $i < count($arguments); $i++) {
                $format[] = '{value:' . ($i - 1) . '}';
            }

            return str_replace($format, $arguments, $message);
        }
```
So I am assuming that the default formatting for Violin should be 3 elements (the field, the input, and the value), so if the number of arguments a rule has is bigger than 3, we need to handle the format for these multiple arguments.
What I did was to add the rest of the values into a new array and replace the string with the arguments based on that new format so that we can do:
```php
$v->addRuleMessage('between', '{field} must be between [{value}, {value:1}].');

$v->validate('age' => 20, ['age' => 'between(10, 20)']);
```

What do you think about the changes I've made? If anything is unclear let me know!