### PR TITLE
Changed the way arguments are handled

### DIFF
--- a/src/Rules/BetweenRule.php
+++ b/src/Rules/BetweenRule.php
@@ -11,8 +11,8 @@ class BetweenRule
      * @param  mixed $value
      * @return bool
      */
-    public function run($name, $value, $param1, $param2)
+    public function run($name, $value, $args)
     {
-        return ($value >= $param1 && $value <= $param2) ? true : false;
+        return ($value >= $args[0] && $value <= $args[1]) ? true : false;
     }
 }

--- a/src/Rules/MaxRule.php
+++ b/src/Rules/MaxRule.php
@@ -12,8 +12,8 @@ class MaxRule
      * @param mixed $param1
      * @return bool
      */
-    public function run($name, $value, $param1)
+    public function run($name, $value, $args)
     {
-        return (float) $value <= (float) $param1;
+        return (float) $value <= (float) $args[0];
     }
 }

--- a/src/Rules/MinRule.php
+++ b/src/Rules/MinRule.php
@@ -12,8 +12,8 @@ class MinRule
      * @param mixed $param1
      * @return bool
      */
-    public function run($name, $value, $param1)
+    public function run($name, $value, $args)
     {
-        return (float) $value >= (float) $param1;
+        return (float) $value >= (float) $args[0];
     }
 }

--- a/src/Validator/Validator.php
+++ b/src/Validator/Validator.php
@@ -50,7 +50,7 @@ class Validator
      *
      * @var array
      */
-    protected $errors;
+    public $errors;
 
     /**
      * Custom defined rules
@@ -151,8 +151,6 @@ class Validator
     protected function replaceMessageFormat($message, $arguments)
     {
         if (isset($arguments[2])) {
-            // If the array arguments are set, it means we have
-            // arguments, so need to loop and replace in a new format.
 
             $format = $this->format;
 
@@ -177,21 +175,13 @@ class Validator
     {
         $messages = [];
 
-        foreach ($this->errors as $field => $proprieties) {
-            $messages[$field] = [];
+        foreach ($this->errors as $rule => $properties) {
 
-            foreach ($proprieties['errors'] as $messageKey) {
-                // If a field message has been set, we use this as preference.
-                // Otherwise, we use the standard rule messages.
-                $message = isset($this->fieldMessages[$field][$messageKey])
-                    ? $this->fieldMessages[$field][$messageKey]
-                    : $this->ruleMessages[$messageKey];
+            $message = isset($this->fieldMessages[$properties[0]][$rule])
+                ? $this->fieldMessages[$properties[0]][$rule]
+                : $this->ruleMessages[$rule];
 
-                // Initiate the replacement of the string.
-                $message = $this->replaceMessageFormat($message, $proprieties['args']);
-
-                array_push($messages[$field], $message);
-            }
+            $messages[$properties[0]][] = $this->replaceMessageFormat($message, $properties);
         }
 
         return new MessageBag($messages);
@@ -214,18 +204,9 @@ class Validator
      * @param  array $args
      * @return void
      */
-    public function error($messageKey, $args)
+    public function error($rule, $args)
     {
-        // Extract the field name from the arguments.
-        $field = $args[0];
-
-        $this->errors[$field]['args'] = $args;
-
-        if (!array_key_exists('errors', $this->errors[$field])) {
-            $this->errors[$field]['errors'] = [];
-        }
-
-        array_push($this->errors[$field]['errors'], $messageKey);
+        $this->errors[$rule] = $args;
     }
 
     /**

--- a/src/Validator/Validator.php
+++ b/src/Validator/Validator.php
@@ -151,7 +151,6 @@ class Validator
     protected function replaceMessageFormat($message, $arguments)
     {
         if (isset($arguments[2])) {
-
             $format = $this->format;
 
             for ($i = 2; $i < count($arguments); $i++) {
@@ -176,7 +175,6 @@ class Validator
         $messages = [];
 
         foreach ($this->errors as $rule => $properties) {
-
             $message = isset($this->fieldMessages[$properties[0]][$rule])
                 ? $this->fieldMessages[$properties[0]][$rule]
                 : $this->ruleMessages[$rule];


### PR DESCRIPTION
This fixes #21 where arguments are flattened too early, meaning any values sent through an Array rule are broken up too soon.

It also clears up the way errors are stored, making for less code.