### PR TITLE
Fix to stop empty values from being validated

### DIFF
--- a/src/Contracts/RuleContract.php
+++ b/src/Contracts/RuleContract.php
@@ -4,7 +4,30 @@ namespace Violin\Contracts;
 
 interface RuleContract
 {
+    /**
+     * Runs the rule to check validity. Returning false fails
+     * the check and returning true passes the check.
+     * 
+     * @param  mixed $value
+     * @param  array $input
+     * @param  array $args
+     * 
+     * @return bool
+     */
     public function run($value, $input, $args);
+
+    /**
+     * The error given if the rule fails.
+     * 
+     * @return string
+     */
     public function error();
+
+    /**
+     * If the rule can be skipped, if the value given
+     * to the validator is not required.
+     * 
+     * @return [type] [description]
+     */
     public function canSkip();
 }

--- a/src/Contracts/RuleContract.php
+++ b/src/Contracts/RuleContract.php
@@ -5,6 +5,5 @@ namespace Violin\Contracts;
 interface RuleContract
 {
     public function run($value, $input, $args);
-
     public function error();
 }

--- a/src/Contracts/RuleContract.php
+++ b/src/Contracts/RuleContract.php
@@ -6,4 +6,5 @@ interface RuleContract
 {
     public function run($value, $input, $args);
     public function error();
+    public function canSkip();
 }

--- a/src/Contracts/RuleContract.php
+++ b/src/Contracts/RuleContract.php
@@ -7,18 +7,18 @@ interface RuleContract
     /**
      * Runs the rule to check validity. Returning false fails
      * the check and returning true passes the check.
-     * 
+     *
      * @param  mixed $value
      * @param  array $input
      * @param  array $args
-     * 
+     *
      * @return bool
      */
     public function run($value, $input, $args);
 
     /**
      * The error given if the rule fails.
-     * 
+     *
      * @return string
      */
     public function error();
@@ -26,7 +26,7 @@ interface RuleContract
     /**
      * If the rule can be skipped, if the value given
      * to the validator is not required.
-     * 
+     *
      * @return [type] [description]
      */
     public function canSkip();

--- a/src/Rules/AlnumDashRule.php
+++ b/src/Rules/AlnumDashRule.php
@@ -15,4 +15,9 @@ class AlnumDashRule implements RuleContract
     {
         return '{field} must be alphanumeric with dashes and underscores permitted.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/AlnumRule.php
+++ b/src/Rules/AlnumRule.php
@@ -15,4 +15,9 @@ class AlnumRule implements RuleContract
     {
         return '{field} must be alphanumeric.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/AlphaRule.php
+++ b/src/Rules/AlphaRule.php
@@ -15,4 +15,9 @@ class AlphaRule implements RuleContract
     {
         return '{field} must be alphabetic.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/ArrayRule.php
+++ b/src/Rules/ArrayRule.php
@@ -15,4 +15,9 @@ class ArrayRule implements RuleContract
     {
         return '{field} must be an array.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/BetweenRule.php
+++ b/src/Rules/BetweenRule.php
@@ -15,4 +15,9 @@ class BetweenRule implements RuleContract
     {
         return '{field} must be between {arg0} and {arg1}.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/BoolRule.php
+++ b/src/Rules/BoolRule.php
@@ -15,4 +15,9 @@ class BoolRule implements RuleContract
     {
         return '{field} must be a boolean.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/CheckedRule.php
+++ b/src/Rules/CheckedRule.php
@@ -15,4 +15,9 @@ class CheckedRule implements RuleContract
     {
         return 'You need to check the {field} field.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/DateRule.php
+++ b/src/Rules/DateRule.php
@@ -25,4 +25,9 @@ class DateRule implements RuleContract
     {
         return '{field} must be a valid date.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/EmailRule.php
+++ b/src/Rules/EmailRule.php
@@ -15,4 +15,9 @@ class EmailRule implements RuleContract
     {
         return '{field} must be a valid email address.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/IntRule.php
+++ b/src/Rules/IntRule.php
@@ -15,4 +15,9 @@ class IntRule implements RuleContract
     {
         return '{field} must be a number.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/IpRule.php
+++ b/src/Rules/IpRule.php
@@ -15,4 +15,9 @@ class IpRule implements RuleContract
     {
         return '{field} must be a valid IP address.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/MatchesRule.php
+++ b/src/Rules/MatchesRule.php
@@ -15,4 +15,9 @@ class MatchesRule implements RuleContract
     {
         return '{field} must match {arg0}.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/MaxRule.php
+++ b/src/Rules/MaxRule.php
@@ -21,4 +21,9 @@ class MaxRule implements RuleContract
     {
         return '{field} must be a maximum of {arg0}.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/MinRule.php
+++ b/src/Rules/MinRule.php
@@ -21,4 +21,9 @@ class MinRule implements RuleContract
     {
         return '{field} must be a minimum of {arg0}.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/NumberRule.php
+++ b/src/Rules/NumberRule.php
@@ -15,4 +15,9 @@ class NumberRule implements RuleContract
     {
         return '{field} must be a number.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/RegexRule.php
+++ b/src/Rules/RegexRule.php
@@ -15,4 +15,9 @@ class RegexRule implements RuleContract
     {
         return '{field} was not in the correct format.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Rules/RequiredRule.php
+++ b/src/Rules/RequiredRule.php
@@ -6,8 +6,6 @@ use Violin\Contracts\RuleContract;
 
 class RequiredRule implements RuleContract
 {
-    public $skipIfEmpty = false;
-
     public function run($value, $input, $args)
     {
         $value = preg_replace('/^[\pZ\pC]+|[\pZ\pC]+$/u', '', $value);
@@ -18,5 +16,10 @@ class RequiredRule implements RuleContract
     public function error()
     {
         return '{field} is required.';
+    }
+
+    public function canSkip()
+    {
+        return false;
     }
 }

--- a/src/Rules/RequiredRule.php
+++ b/src/Rules/RequiredRule.php
@@ -6,6 +6,8 @@ use Violin\Contracts\RuleContract;
 
 class RequiredRule implements RuleContract
 {
+    public $skipIfEmpty = false;
+
     public function run($value, $input, $args)
     {
         $value = preg_replace('/^[\pZ\pC]+|[\pZ\pC]+$/u', '', $value);

--- a/src/Rules/UrlRule.php
+++ b/src/Rules/UrlRule.php
@@ -15,4 +15,9 @@ class UrlRule implements RuleContract
     {
         return '{field} must be a valid URL.';
     }
+
+    public function canSkip()
+    {
+        return true;
+    }
 }

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -267,10 +267,10 @@ class Violin implements ValidatorContract
      * don't need to validate an empty value. If the rule to
      * call specifically doesn't allowing skipping, then
      * we don't want skip the rule.
-     * 
+     *
      * @param  array $ruleToCall
      * @param  mixed $value
-     * 
+     *
      * @return null
      */
     protected function canSkipRule($ruleToCall, $value)

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -278,7 +278,8 @@ class Violin implements ValidatorContract
         return (
             (!isset($ruleToCall[0]->skipIfEmpty) ||
             $ruleToCall[0]->skipIfEmpty === true) &&
-            empty($value)
+            empty($value) &&
+            !is_array($value)
         );
     }
 

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -247,6 +247,10 @@ class Violin implements ValidatorContract
     {
         $ruleToCall = $this->getRuleToCall($rule);
 
+        if (is_array($ruleToCall) && $this->canSkipRule($ruleToCall, $value)) {
+            return;
+        }
+        
         $passed = call_user_func_array($ruleToCall, [
             $value,
             $this->input,
@@ -256,6 +260,26 @@ class Violin implements ValidatorContract
         if (!$passed) {
             $this->handleError($field, $value, $rule, $args);
         }
+    }
+
+    /**
+     * Method to help skip a rule if a value is empty, since we
+     * don't need to validate an empty value. If the rule to
+     * call specifically doesn't allowing skipping, then
+     * we don't want skip the rule.
+     * 
+     * @param  array $ruleToCall
+     * @param  mixed $value
+     * 
+     * @return null
+     */
+    protected function canSkipRule($ruleToCall, $value)
+    {
+        return (
+            (!isset($ruleToCall[0]->skipIfEmpty) ||
+            $ruleToCall[0]->skipIfEmpty === true) &&
+            empty($value)
+        );
     }
 
     /**

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -272,7 +272,7 @@ class Violin implements ValidatorContract
     {
         $ruleToCall = $this->getRuleToCall($rule);
 
-        if (is_array($ruleToCall) && $this->canSkipRule($ruleToCall, $value)) {
+        if ($this->canSkipRule($ruleToCall, $value)) {
             return;
         }
         
@@ -301,8 +301,8 @@ class Violin implements ValidatorContract
     protected function canSkipRule($ruleToCall, $value)
     {
         return (
-            (!isset($ruleToCall[0]->skipIfEmpty) ||
-            $ruleToCall[0]->skipIfEmpty === true) &&
+            (is_array($ruleToCall) &&
+            $ruleToCall[0]->canSkip()) &&
             empty($value) &&
             !is_array($value)
         );

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -241,4 +241,14 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
             'We need a username in the Username field, please.'
         );
     }
+
+    public function testSkippingOtherRulesIfNotRequired()
+    {
+        $this->v->validate([
+            'username' => ['alex', 'required|alpha'],
+            'email' => ['', 'alpha|email']
+        ]);
+
+        $this->assertEmpty($this->v->errors()->all());
+    }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -77,9 +77,11 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
         $this->v->validate([
             'username' => '',
+            'name' => '123',
             'email' => 'notanemail'
         ], [
             'username' => 'required|alpha',
+            'name' => 'alpha|max(30)',
             'email' => 'required|email'
         ]);
 
@@ -87,7 +89,12 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $errors->get('username'),
-            ['This field is required!', 'Only alpha characters please!']
+            ['This field is required!']
+        );
+
+        $this->assertEquals(
+            $errors->first('name'),
+            'Only alpha characters please!'
         );
 
         $this->assertEquals(
@@ -113,8 +120,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
     {
         $this->v->addFieldMessages([
             'username' => [
-                'required' => 'We need a username, please.',
-                'alpha' => 'Alpha characters in that username only, please.',
+                'required' => 'We need a username, please.'
             ],
             'email' => [
                 'required' => 'How do you expect us to contact you without an email?'
@@ -133,7 +139,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $errors->get('username'),
-            ['We need a username, please.', 'Alpha characters in that username only, please.']
+            ['We need a username, please.']
         );
         
         $this->assertEquals(


### PR DESCRIPTION
This fixes a massive problem when values are not required (RequiredRule) and contain an empty value. This causes every other rule to be run.

Stupid example:

```php
$v->validate([
    'username' => ['alex', 'required|alpha'],
    'name' => ['', 'alpha|email']
]);
```

The above would still attempt to check AlphaRule and EmailRule even though it doesn't need to be checked.