### PR TITLE
Allow the validate method to receive the rules array or perform a direct validation.

### DIFF
--- a/src/Contracts/ValidatorContract.php
+++ b/src/Contracts/ValidatorContract.php
@@ -6,7 +6,7 @@ use Closure;
 
 interface ValidatorContract
 {
-    public function validate(array $input);
+    public function validate(array $input, $rules = []);
     public function passes();
     public function fails();
     public function errors();

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -64,23 +64,29 @@ class Violin implements ValidatorContract
     /**
      * Kick off the validation using input and rules.
      *
-     * @param  array  $data
+     * @param  array  $input
+     * @param  array  $rules
      *
-     * @return void
+     * @return this
      */
-    public function validate(array $data)
+    public function validate(array $data, $rules = [])
     {
         $this->clearErrors();
         $this->clearFieldAliases();
 
         $data = $this->extractFieldAliases($data);
 
-        $input = $this->extractInput($data);
-        $rules = $this->extractRules($data);
+        // If the rules array is empty, then it means we are
+        // receiving the rules directly with the input, so we need
+        // to extract the information.
+        if (empty($rules)) {
+            $rules = $this->extractRules($data);
+            $data  = $this->extractInput($data);
+        }
 
-        $this->input = $input;
+        $this->input = $data;
 
-        foreach ($input as $field => $value) {
+        foreach ($data as $field => $value) {
             $fieldRules = explode('|', $rules[$field]);
 
             foreach ($fieldRules as $rule) {
@@ -92,6 +98,8 @@ class Violin implements ValidatorContract
                 );
             }
         }
+
+        return $this;
     }
 
     /**

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -16,10 +16,31 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->v->validate([
             'first_name'     => ['Billy', 'required|alpha|max(20)'],
             'last_name'      => ['Garrett', 'required|alpha|max(20)'],
-            'email'          => ['billy@codecourse.com', 'required|email'],
+            'email|Email'    => ['billy@codecourse.com', 'required|email'],
             'password'       => ['ilovecats', 'required'],
             'password_again' => ['ilovecats', 'required|matches(password)']
         ]);
+
+        $this->assertTrue($this->v->passes());
+        $this->assertFalse($this->v->fails());
+
+        $input = [
+            'first_name'  => 'Billy',
+            'last_name'   => 'Garrett',
+            'email|Email' => 'billy@codecourse.com',
+            'password'    => 'ilovecats',
+            'password'    => 'ilovecats'
+        ];
+
+        $rules = [
+            'first_name'     => 'required|alpha|max(20)',
+            'last_name'      => 'required|alpha|max(20)',
+            'email'          => 'required|email',
+            'password'       => 'required',
+            'password_again' => 'required|matches(password)'
+        ];
+
+        $this->v->validate($input, $rules);
 
         $this->assertTrue($this->v->passes());
         $this->assertFalse($this->v->fails());


### PR DESCRIPTION
I also allowed the validate method to return the Violin instance.
So we can call passes/fails easier.
Example:

```php
$v = new Violin\Violin;

$data = [
    'name' => ['Billy', 'required|alpha']
];

if ($v->validate($data)->passes()) {
   // Do something ..
} else {
   // Handle errors ..
}
```

Also, there is no need to write aliases twice (in the input and in the rules arrays). Since that would be hard to manage, all of the aliases are registered only in the input array. The Basic Validation test covers this.