### PR TITLE
composer: fix cs, add min PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,27 @@
 {
-    "name": "alexgarrett/violin",
-    "type": "library",
-    "description": "Violin is an easy to use, highly customisable PHP validator.",
-    "keywords": ["validation"],
-    "homepage": "https://github.com/alexgarrett/violin",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Alex Garrett",
-            "email": "alex@codecourse.com",
-            "homepage": "http://itsmealex.com"
-        }
-    ],
-    "require-dev": {
-        "squizlabs/php_codesniffer": "2.1.*",
-        "phpunit/phpunit": "4.5.0"
-    },
+	"name": "alexgarrett/violin",
+	"type": "library",
+	"description": "Violin is an easy to use, highly customisable PHP validator.",
+	"keywords": ["validation"],
+	"homepage": "https://github.com/alexgarrett/violin",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Alex Garrett",
+			"email": "alex@codecourse.com",
+			"homepage": "http://itsmealex.com"
+		}
+	],
+	"require": {
+		"php": ">=5.4"
+	},
+	"require-dev": {
+		"squizlabs/php_codesniffer": "2.1.*",
+		"phpunit/phpunit": "~4.5"
+	},
 	"autoload": {
 		"psr-4": {
-            "Violin\\": "src/"
-        }
+			"Violin\\": "src/"
+		}
 	}
 }


### PR DESCRIPTION
According to travis, min version is PHP 5.4

Also use major version 4 for PHPUnit (there is great BC between minor versions, so no need to lock it down IMO).