### PR TITLE
Changed argument formats and some small parts in the code.

### DIFF
--- a/src/Rules/BetweenRule.php
+++ b/src/Rules/BetweenRule.php
@@ -13,6 +13,6 @@ class BetweenRule implements RuleContract
 
     public function error()
     {
-        return '{field} must be between {arg0} and {arg1}.';
+        return '{field} must be between {$0} and {$1}.';
     }
 }

--- a/src/Rules/MatchesRule.php
+++ b/src/Rules/MatchesRule.php
@@ -13,6 +13,6 @@ class MatchesRule implements RuleContract
 
     public function error()
     {
-        return '{field} must match {arg0}.';
+        return '{field} must match {$0}.';
     }
 }

--- a/src/Rules/MaxRule.php
+++ b/src/Rules/MaxRule.php
@@ -19,6 +19,6 @@ class MaxRule implements RuleContract
 
     public function error()
     {
-        return '{field} must be a maximum of {arg0}.';
+        return '{field} must be a maximum of {$0}.';
     }
 }

--- a/src/Rules/MinRule.php
+++ b/src/Rules/MinRule.php
@@ -19,6 +19,6 @@ class MinRule implements RuleContract
 
     public function error()
     {
-        return '{field} must be a minimum of {arg0}.';
+        return '{field} must be a minimum of {$0}.';
     }
 }

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -119,7 +119,7 @@ class Violin implements ValidatorContract
      */
     public function fails()
     {
-        return !empty($this->errors);
+        return ! $this->passes();
     }
 
     /**
@@ -240,8 +240,16 @@ class Violin implements ValidatorContract
             $args = $item['args'];
 
             $argReplace = array_map(function($i) {
-                return "{arg{$i}}";
+                return "{\${$i}}";
             }, array_keys($args));
+
+            // Number of arguments
+            $args[] = count($item['args']);
+            $argReplace[] = '{$#}';
+
+            // All arguments
+            $args[] = implode(', ', $item['args']);
+            $argReplace[] = '{$*}';
 
             // Replace arguments
             $message = str_replace($argReplace, $args, $message);
@@ -455,6 +463,7 @@ class Violin implements ValidatorContract
 
     /**
      * Extract the field ruleset from the data array.
+     *
      * @param  array  $data
      * @return array
      */

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -74,6 +74,24 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testReplaceMessageFormatOnError()
+    {
+        $this->v->addRule('testRule', function($value, $input, $args) {
+            return false;
+        });
+
+        $this->v->addRuleMessage('testRule', 'We got {$#} arguments: {$*}.');
+
+        $this->v->validate([
+            'age' => [0, 'testRule(1, 2, 3)']
+        ]);
+
+        $this->assertEquals(
+            $this->v->errors()->first(),
+            'We got 3 arguments: 1, 2, 3.'
+        );
+    }
+
     public function testRuleMessages()
     {
         $this->v->addRuleMessages([


### PR DESCRIPTION
I have changed the syntax of the format of the arguments. Instead of calling {arg0}, {arg1}, ... I call them with {$0}, {$1}, ...

Also I have added {$#} which gives us the number of arguments we need, and {$*} which returns a string with all of the arguments.

Even though it was a straight forward implementation, I believe we can improve the way we handle formatting.