### PR TITLE
Empty values & Required Rule

### DIFF
--- a/src/Rules/RequiredRule.php
+++ b/src/Rules/RequiredRule.php
@@ -9,7 +9,11 @@ class RequiredRule implements RuleContract
     public function run($value, $input, $args)
     {
         $value = preg_replace('/^[\pZ\pC]+|[\pZ\pC]+$/u', '', $value);
-
+        
+        if($value === '0'){
+			return true;
+		}
+		
         return !empty($value);
     }
 

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -312,10 +312,33 @@ class Violin implements ValidatorContract
             (is_array($ruleToCall) &&
             method_exists($ruleToCall[0], 'canSkip') &&
             $ruleToCall[0]->canSkip()) &&
-            empty($value) &&
+            $this->isEmpty($value) &&
             !is_array($value)
         );
     }
+    
+    /**
+     * Determines if the given value is actually empty,
+     * Values: '0', false, 0, and 0.0 are considered as non-empty values.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+	protected function isEmpty($value)
+	{
+		if(is_null($value)) {
+            return true;
+        }
+        else if(is_string($value)){
+            if(trim($value) === '') {
+				return true;
+			}
+        }
+        else if (empty($value) && $value !== '0' && $value !== false && $value !== 0 && $value !== 0.0){
+            return true;
+        }
+        return false;
+	}
 
     /**
      * Clears all previously stored errors.

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -88,7 +88,13 @@ class Violin implements ValidatorContract
 
         foreach ($data as $field => $value) {
             $fieldRules = explode('|', $rules[$field]);
-
+            
+            // It doesn't make sense to continue and validate the rest of rules 
+			// if the value is required and empty.
+			if(in_array("required", array_map('strtolower', $fieldRules)) && $this->isEmpty($value)){
+				$fieldRules = ["required"];
+			}
+			
             foreach ($fieldRules as $rule) {
                 $this->validateAgainstRule(
                     $field,


### PR DESCRIPTION
1. Empty Values

If you tried to validate the following values:

```php
$v = new Violin;

$v->validate([ 
   'username'  => ['                ', 'max(5)'],
   'age'  => ['0', 'between(12,24)']
]);
```

- For 'username', You will get "username must be a maximum of 5." error. Although the string is an empty string(should be trimmed).
- For 'age', You won't get any errors although zero(0 or '0') is a valid value, and It's not between 12 and 24.

This is because you are using ``` empty() ``` inside ``` canSkipRule() ```  method. ``` empty() ``` returns true in case of zeros, and it won't trim string values.

So, A better way is to have a method that excludes all values like 0, '0', false, 0.0, and trim string and check if it's empty or not.

Commit: [beee614](https://github.com/alexgarrett/violin/commit/beee61449fd3963a8832729c5b8c3cf3e115cd87)

2. Required Rule

```php
$v = new Violin;

$v->validate([ 
   'score'  => ['0', 'required|number|between(0,4)']
]);
```
You will get "score is required.", Although '0' is a perfectly valid value, and not empty. 

Inside ``` RequiredRule ```,  You are using 

```php 
preg_replace('/^[\pZ\pC]+|[\pZ\pC]+$/u', '', $value); 
```
So, the value passed will be string, So, you need to exclude '0', and consider it as non empty value.

null and false values will be empty strings, So, ``` RequiredRule ``` will return false, which is valid.

Commit: [d364e1e](https://github.com/alexgarrett/violin/commit/d364e1e4ae09b3aa6a3465f3b58b2354b0506cd5)

3. If value is required and empty, Why to continue and validate the rest of rules?

```php
$v = new Violin;

$v->validate([ 
   'username'  => ['                ', 'required|max(5)']
]);
```

Assuming that you have merged ``` isEmpty() ``` method in Violin Class. The above rule won't check for max(5), and will return "username is required." error. This is because  ```  canSkipRule()  ```  method will return true for the rule max(5). 

But, It's still better to skip all rules if value is required and empty.

So, The solution that I see suitable without breaking the logic, 
Inside ``` validate()``` method check if 'required' rule(case in-sensitive) is within ``` $fieldRules ``` and value is empty, then re-initialize the ``` $fieldRules ``` to be assigned only to 'required' rule.

Commit: [a67188e](https://github.com/alexgarrett/violin/commit/a67188e54f863e579c6ebd34659f31ca21668236)

In other frameworks, they wouldn't have RequiredRule, 
Instead they can have for example method called ``` requirePresence() or  isRequired() ```.

This method will then create an array of all required fields, and append field to the array whenever it's called.

Then, inside ``` validate() ``` method, Check if the current field is in the array of required fields and and it's value is empty, If so, then add "{field} is required error", and move on to the next rule.

**OR**

A simpler solution is to keep everything as it's, just check if 'required' is within the ``` $fieldRules ```  and value is empty, If so, then add "{field} is required error", and move on to the next rule.

But, Both of them have their pitfalls, because they will break the logic of the application and bring up bugs if not implemented correctly.

So, I came across intermediate solution in my last commit [a67188e](https://github.com/alexgarrett/violin/commit/a67188e54f863e579c6ebd34659f31ca21668236)