### PR TITLE
Allows Data without a Rule

### DIFF
--- a/src/Violin.php
+++ b/src/Violin.php
@@ -78,7 +78,7 @@ class Violin implements ValidatorContract
     /**
      * Kick off the validation using input and rules.
      *
-     * @param  array  $input
+     * @param  array  $data
      * @param  array  $rules
      *
      * @return this
@@ -106,6 +106,12 @@ class Violin implements ValidatorContract
         }
 
         foreach ($data as $field => $value) {
+
+            // If there is no rule for the current data field, then skip
+            if (!isset($rules[$field])) {
+                break;
+            }
+
             $fieldRules = explode('|', $rules[$field]);
 
             foreach ($fieldRules as $rule) {

--- a/src/Violin.php
+++ b/src/Violin.php
@@ -106,7 +106,6 @@ class Violin implements ValidatorContract
         }
 
         foreach ($data as $field => $value) {
-
             // If there is no rule for the current data field, then skip
             if (!isset($rules[$field])) {
                 break;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -319,4 +319,35 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
             'You need to have less than 3 characters.'
         );
     }
+
+    public function testSeparateDataAndRules()
+    {
+        $data = [
+            'username' => 'alexgarrett'
+        ];
+
+        $rules = [
+            'username' => 'alnum'
+        ];
+
+        $this->v->validate($data, $rules);
+
+        $this->assertTrue($this->v->passes());
+    }
+
+    public function testSeparateDataAndRulesWithMissingRule()
+    {
+        $data = [
+            'username' => 'alexgarrett',
+            'password' => '123456'
+        ];
+
+        $rules = [
+            'username' => 'alnum'
+        ];
+
+        $this->v->validate($data, $rules);
+
+        $this->assertTrue($this->v->passes());
+    }
 }


### PR DESCRIPTION
We ran into a strange issue where we were passing our data into the validator, as an array, from an object. However we only have rules for a portion of these, since we only validate what's necessary.

When you consider this case, we were getting an undefined index (example below).

```
// this gets all fields on the object
// one of the fields 'gender' doesn't have an associated rule, 
// this is because we don't necessarily want to validate it
$dataDump = $ourObject->toArray();
$this->v->validate($dataDump, $rules);
```

Error thrown:
```
Undefined index: gender
```

I've just added a simple conditional to account for this, and 'skip' the validation if there is no rule for the data.