### PR TITLE
Added alternative 'get' function to messageBag

### DIFF
--- a/src/Support/MessageBag.php
+++ b/src/Support/MessageBag.php
@@ -85,6 +85,16 @@ class MessageBag implements MessageBagContract
     }
 
     /**
+     * Get all messages with key
+     *
+     * @return array
+     */
+    public function allWithKey()
+    {
+        return $this->messages;
+    }
+
+    /**
      * Checks if the bag is empty.
      *
      * @return boolean


### PR DESCRIPTION
I noticed that currently you need to loop through a list of fieldnames to get all the errors and the `$violinInstance->errors()->all()` is indexed with numbers making it hard to place the errors to it's corresponding input.
I thought it would be useful to be able to get the whole  `MessageBag::$message` as the messages are nicely ordered into the corresponding field making it very easy to pass to views and templates. 
Calling the `$violinInstance->errors()->get('field')` function wouldn't work in a templating languages like twig unless you specifically told twig it was allowed to use that function. And to me adding this little function seems cleaner as you can pass the result of the function right into the `$twigInstance->render()` function.

Below is an example of when this would be useful.

example.php

``` php
<?php
require_once '../vendor/autoload.php';

$loader = new \Twig_Loader_Filesystem('.');
$twigInstance = new \Twig_Environment($loader, [/*twig options*/]);

$validator = new Violin\Violin();
$validator->validate([
    'password|Password' => [$_POST['password'], 'required|min(3)|max(40)'],
]);

if ($validator->fails()) {
  echo $twigInstance->render('form.twig', [
    'errors' => $validator->errors()->allWithKey(),
  ]);
}
else {
  echo $twigInstance->render('continue.twig', [
  ]);
}


```

form.twig

``` twig
<form action="example.php" method="post">
        <input name="password" />
        {% for error in errors.password %}
              {{ error }}
              <br/>
        {% endfor %}
        <input type="submit" value="Submit">
    </form>

```
