### PR TITLE
Add PHP 7.1 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
Since a new version of PHP has been released I think it's good to add it to the list of PHP versions to test.